### PR TITLE
Fix FFI usage

### DIFF
--- a/Gnuplot.bqn
+++ b/Gnuplot.bqn
@@ -1,6 +1,6 @@
 Gnuplotpipe ← {𝕊𝕩:
-  popen ← @ •FFI ⟨"*:i32","popen","*i32:c8","*i32:c8"⟩
-  fputs ← @ •FFI ⟨"i32","fputs","*i32:c8","*:i32"⟩
+  popen ← @ •FFI ⟨"*:i32","popen","*i8:c8","*i8:c8"⟩
+  fputs ← @ •FFI ⟨"i32","fputs","*i8:c8","*:i32"⟩
   pclose ← @ •FFI ⟨"i32", "pclose",">*:i32"⟩
   fp ← POpen ⟨"gnuplot --persist"∾@,"w"∾@⟩
   FPuts ⟨𝕩∾@,fp⟩


### PR DESCRIPTION
`"*i32:c8"` is not the correct type to use for an arbitrary character list, as it's for `i32` elements, i.e. multiples of 4 elements. CBQN a while ago didn't bother erroring on this, but has for a while, thus having left this library broken.